### PR TITLE
new tools from Bioconda

### DIFF
--- a/data/bam2fasta/bioconda_bam2fasta.yaml
+++ b/data/bam2fasta/bioconda_bam2fasta.yaml
@@ -1,5 +1,8 @@
+biotools_id: bam2fasta
 dev_url: https://github.com/czbiohub/bam2fasta
 home: https://github.com/czbiohub/bam2fasta
+identifiers:
+- biotools:bam2fasta
 license: MIT License
 license_family: MIT
 license_file: LICENSE

--- a/data/bam2fasta/bioconda_bam2fasta.yaml
+++ b/data/bam2fasta/bioconda_bam2fasta.yaml
@@ -1,0 +1,8 @@
+dev_url: https://github.com/czbiohub/bam2fasta
+home: https://github.com/czbiohub/bam2fasta
+license: MIT License
+license_family: MIT
+license_file: LICENSE
+name: bam2fasta
+summary: 'bam2fasta: cli tool to convert bam to fastas'
+version: 1.0.1

--- a/data/bold-identification/bioconda_bold-identification.yaml
+++ b/data/bold-identification/bioconda_bold-identification.yaml
@@ -1,0 +1,8 @@
+home: https://github.com/linzhi2013/bold_identification
+license: GNU General Public v3 or later (GPLv3+)
+license_family: GPL3
+license_file: LICENSE
+name: bold-identification
+summary: A tool for taxonomic assignment for given sequences using the BOLD database
+  (http://www.boldsystems.org/index.php)
+version: 0.0.25

--- a/data/bold-identification/bioconda_bold-identification.yaml
+++ b/data/bold-identification/bioconda_bold-identification.yaml
@@ -1,4 +1,7 @@
+biotools_id: bold-identification
 home: https://github.com/linzhi2013/bold_identification
+identifiers:
+- biotools:bold-identification
 license: GNU General Public v3 or later (GPLv3+)
 license_family: GPL3
 license_file: LICENSE

--- a/data/chorus2/bioconda_chorus2.yaml
+++ b/data/chorus2/bioconda_chorus2.yaml
@@ -1,6 +1,9 @@
+biotools_id: chorus2
 dev_url: https://github.com/zhangtaolab/Chorus2
 doc_url: https://chorus2.readthedocs.io/en/dev/
 home: https://github.com/zhangtaolab/Chorus2
+identifiers:
+- biotools:chorus2
 license: MIT license
 name: chorus2
 summary: A pipeline to select oligonucleotides for fluorescence in situ hbridization

--- a/data/chorus2/bioconda_chorus2.yaml
+++ b/data/chorus2/bioconda_chorus2.yaml
@@ -1,0 +1,8 @@
+dev_url: https://github.com/zhangtaolab/Chorus2
+doc_url: https://chorus2.readthedocs.io/en/dev/
+home: https://github.com/zhangtaolab/Chorus2
+license: MIT license
+name: chorus2
+summary: A pipeline to select oligonucleotides for fluorescence in situ hbridization
+  (Oligo-FISH).
+version: 2.0

--- a/data/extract_fasta_seq/bioconda_extract_fasta_seq.yaml
+++ b/data/extract_fasta_seq/bioconda_extract_fasta_seq.yaml
@@ -1,0 +1,7 @@
+home: https://github.com/linzhi2013/extract_fasta_seq
+license: GNU General Public v3 or later (GPLv3+)
+license_family: GPL3
+license_file: LICENSE
+name: extract_fasta_seq
+summary: To extract specific fasta sequences from a fasta file.
+version: 0.0.1

--- a/data/extract_fasta_seq/bioconda_extract_fasta_seq.yaml
+++ b/data/extract_fasta_seq/bioconda_extract_fasta_seq.yaml
@@ -1,4 +1,7 @@
+biotools_id: extract_fasta_seq
 home: https://github.com/linzhi2013/extract_fasta_seq
+identifiers:
+- biotools:extract_fasta_seq
 license: GNU General Public v3 or later (GPLv3+)
 license_family: GPL3
 license_file: LICENSE

--- a/data/faqcs/bioconda_faqcs.yaml
+++ b/data/faqcs/bioconda_faqcs.yaml
@@ -1,0 +1,6 @@
+home: https://github.com/LANL-Bioinformatics/FaQCs
+license: BSD 3-Clause
+license_file: LICENSE
+name: faqcs
+summary: Quality Control of Next Generation Sequencing Data.
+version: 2.09

--- a/data/faqcs/bioconda_faqcs.yaml
+++ b/data/faqcs/bioconda_faqcs.yaml
@@ -1,4 +1,7 @@
+biotools_id: faqcs
 home: https://github.com/LANL-Bioinformatics/FaQCs
+identifiers:
+- biotools:faqcs
 license: BSD 3-Clause
 license_file: LICENSE
 name: faqcs

--- a/data/gem_mapper/bioconda_gem_mapper.yaml
+++ b/data/gem_mapper/bioconda_gem_mapper.yaml
@@ -1,4 +1,8 @@
+biotools_id: gem_mapper
 home: https://github.com/smarco/gem3-mapper
+identifiers:
+- doi:10.1038/nmeth.2221
+- biotools:GEM_Mapper
 license: GPL-3.0
 license_file: LICENSE
 name: gem3-mapper

--- a/data/gem_mapper/bioconda_gem_mapper.yaml
+++ b/data/gem_mapper/bioconda_gem_mapper.yaml
@@ -1,0 +1,6 @@
+home: https://github.com/smarco/gem3-mapper
+license: GPL-3.0
+license_file: LICENSE
+name: gem3-mapper
+summary: The GEM read mapper (v3).
+version: 3.6.1

--- a/data/ispcr/bioconda_ispcr.yaml
+++ b/data/ispcr/bioconda_ispcr.yaml
@@ -1,0 +1,6 @@
+home: https://users.soe.ucsc.edu/~kent/
+license: License is hereby granted for personal, academic, and non-profit use.
+license_file: README
+name: ispcr
+summary: In silico PCR
+version: 33

--- a/data/ispcr/bioconda_ispcr.yaml
+++ b/data/ispcr/bioconda_ispcr.yaml
@@ -1,4 +1,7 @@
+biotools_id: ispcr
 home: https://users.soe.ucsc.edu/~kent/
+identifiers:
+- biotools:ispcr
 license: License is hereby granted for personal, academic, and non-profit use.
 license_file: README
 name: ispcr

--- a/data/ivar/bioconda_ivar.yaml
+++ b/data/ivar/bioconda_ivar.yaml
@@ -1,5 +1,8 @@
+biotools_id: ivar
 dev_url: https://github.com/andersen-lab/ivar
 home: https://andersen-lab.github.io/ivar/html/
+identifiers:
+- biotools:ivar
 license: GPL-3.0
 license_file: LICENSE
 name: ivar

--- a/data/ivar/bioconda_ivar.yaml
+++ b/data/ivar/bioconda_ivar.yaml
@@ -1,0 +1,8 @@
+dev_url: https://github.com/andersen-lab/ivar
+home: https://andersen-lab.github.io/ivar/html/
+license: GPL-3.0
+license_file: LICENSE
+name: ivar
+summary: iVar is a computational package that contains functions broadly useful for
+  viral amplicon-based sequencing.
+version: 1.0.1

--- a/data/krakenhll/bioconda_krakenhll.yaml
+++ b/data/krakenhll/bioconda_krakenhll.yaml
@@ -1,4 +1,7 @@
+biotools_id: krakenhll
 home: https://github.com/fbreitwieser/krakenuniq
+identifiers:
+- biotools:krakenhll
 license: GPLv3
 license_file: LICENSE
 name: krakenuniq

--- a/data/krakenhll/bioconda_krakenhll.yaml
+++ b/data/krakenhll/bioconda_krakenhll.yaml
@@ -1,0 +1,6 @@
+home: https://github.com/fbreitwieser/krakenuniq
+license: GPLv3
+license_file: LICENSE
+name: krakenuniq
+summary: Metagenomics classifier with unique k-mer counting for more specific results
+version: 0.5.8

--- a/data/ksw/bioconda_ksw.yaml
+++ b/data/ksw/bioconda_ksw.yaml
@@ -1,0 +1,6 @@
+home: https://github.com/nh13/ksw
+license: MIT
+license_file: LICENSE
+name: ksw
+summary: 'Ksw: (interactive) smith-waterman in C'
+version: 0.2.1

--- a/data/ksw/bioconda_ksw.yaml
+++ b/data/ksw/bioconda_ksw.yaml
@@ -1,4 +1,7 @@
+biotools_id: ksw
 home: https://github.com/nh13/ksw
+identifiers:
+- biotools:ksw
 license: MIT
 license_file: LICENSE
 name: ksw

--- a/data/magicblast/bioconda_magicblast.yaml
+++ b/data/magicblast/bioconda_magicblast.yaml
@@ -1,0 +1,17 @@
+description: "Magic-BLAST is a tool for mapping large next-generation RNA or DNA \n\
+  sequencing runs against a whole genome or transcriptome. Each alignment\noptimizes\
+  \ a composite score, taking into account simultaneously the two\nreads of a pair,\
+  \ and in case of RNA-seq, locating the candidate introns\nand adding up the score\
+  \ of all exons. This is very different from other\nversions of BLAST, where each\
+  \ exon is scored as a separate hit and\nread-pairing is ignored.\n\nMagic-BLAST\
+  \ incorporates within the NCBI BLAST code framework ideas \ndeveloped in the NCBI\
+  \ Magic pipeline, in particular hit extensions by local \nwalk and jump (http://www.ncbi.nlm.nih.gov/pubmed/26109056),\
+  \ and \nrecursive clipping of mismatches near the edges of the reads, which avoids\n\
+  accumulating artefactual mismatches near splice sites and is needed to\ndistinguish\
+  \ short indels from substitutions near the edges.\n\nMore details about the algorithm\
+  \ and comparison with other similar tools\nare presented here:\nhttps://bmcbioinformatics.biomedcentral.com/articles/10.1186/s12859-019-2996-x.\n"
+home: https://ncbi.github.io/magicblast/
+license: Public Domain
+name: magicblast
+summary: NCBI BLAST next generation read mapper
+version: 1.5.0

--- a/data/magicblast/bioconda_magicblast.yaml
+++ b/data/magicblast/bioconda_magicblast.yaml
@@ -1,3 +1,4 @@
+biotools_id: magicblast
 description: "Magic-BLAST is a tool for mapping large next-generation RNA or DNA \n\
   sequencing runs against a whole genome or transcriptome. Each alignment\noptimizes\
   \ a composite score, taking into account simultaneously the two\nreads of a pair,\
@@ -11,6 +12,9 @@ description: "Magic-BLAST is a tool for mapping large next-generation RNA or DNA
   \ short indels from substitutions near the edges.\n\nMore details about the algorithm\
   \ and comparison with other similar tools\nare presented here:\nhttps://bmcbioinformatics.biomedcentral.com/articles/10.1186/s12859-019-2996-x.\n"
 home: https://ncbi.github.io/magicblast/
+identifiers:
+- biotools:magicblast
+- doi:10.1186/s12859-019-2996-x
 license: Public Domain
 name: magicblast
 summary: NCBI BLAST next generation read mapper

--- a/data/malt/bioconda_malt.yaml
+++ b/data/malt/bioconda_malt.yaml
@@ -1,0 +1,5 @@
+home: http://ab.inf.uni-tuebingen.de/software/malt/
+license: GPLv3
+name: malt
+summary: A tool for mapping metagenomic data
+version: 0.41

--- a/data/malt/bioconda_malt.yaml
+++ b/data/malt/bioconda_malt.yaml
@@ -1,4 +1,7 @@
+biotools_id: malt
 home: http://ab.inf.uni-tuebingen.de/software/malt/
+identifiers:
+- biotools:malt
 license: GPLv3
 name: malt
 summary: A tool for mapping metagenomic data

--- a/data/malva/bioconda_malva.yaml
+++ b/data/malva/bioconda_malva.yaml
@@ -1,4 +1,7 @@
+biotools_id: malva
 home: https://algolab.github.io/malva/
+identifiers:
+- biotools:malva
 license: GPL-3.0-or-later
 name: malva
 summary: genotyping by Mapping-free ALternate-allele detection of known VAriants

--- a/data/malva/bioconda_malva.yaml
+++ b/data/malva/bioconda_malva.yaml
@@ -1,0 +1,5 @@
+home: https://algolab.github.io/malva/
+license: GPL-3.0-or-later
+name: malva
+summary: genotyping by Mapping-free ALternate-allele detection of known VAriants
+version: 1.1.1

--- a/data/manta9235/bioconda_manta9235.yaml
+++ b/data/manta9235/bioconda_manta9235.yaml
@@ -1,4 +1,7 @@
+biotools_id: manta9235
 home: https://github.com/Illumina/manta
+identifiers:
+- biotools:Manta9235
 license: GPLv3
 name: manta
 summary: Structural variant and indel caller for mapped sequencing data

--- a/data/manta9235/bioconda_manta9235.yaml
+++ b/data/manta9235/bioconda_manta9235.yaml
@@ -1,0 +1,5 @@
+home: https://github.com/Illumina/manta
+license: GPLv3
+name: manta
+summary: Structural variant and indel caller for mapped sequencing data
+version: 1.6.0

--- a/data/mgkit/bioconda_mgkit.yaml
+++ b/data/mgkit/bioconda_mgkit.yaml
@@ -1,4 +1,8 @@
+biotools_id: mgkit
 home: https://github.com/frubino/mgkit
+identifiers:
+- biotools:mgkit
+- doi:10.6084/m9.figshare.1588384
 license: GNU General Public License v2 or later (GPLv2+)
 license_family: GPL2
 name: mgkit

--- a/data/mgkit/bioconda_mgkit.yaml
+++ b/data/mgkit/bioconda_mgkit.yaml
@@ -1,0 +1,6 @@
+home: https://github.com/frubino/mgkit
+license: GNU General Public License v2 or later (GPLv2+)
+license_family: GPL2
+name: mgkit
+summary: Metagenomics Framework
+version: 0.4.1

--- a/data/miniax/bioconda_miniax.yaml
+++ b/data/miniax/bioconda_miniax.yaml
@@ -1,4 +1,7 @@
+biotools_id: miniax
 home: https://github.com/GATB/minia
+identifiers:
+- biotools:miniax
 license: file
 license_file: LICENSE
 name: minia

--- a/data/miniax/bioconda_miniax.yaml
+++ b/data/miniax/bioconda_miniax.yaml
@@ -1,0 +1,7 @@
+home: https://github.com/GATB/minia
+license: file
+license_file: LICENSE
+name: minia
+summary: Minia is a short-read assembler based on a de Bruijn graph, capable of assembling
+  a human genome on a desktop computer in a day.
+version: 3.2.1

--- a/data/mirtop/bioconda_mirtop.yaml
+++ b/data/mirtop/bioconda_mirtop.yaml
@@ -1,4 +1,7 @@
+biotools_id: mirtop
 home: http://github.com/mirtop/mirtop
+identifiers:
+- biotools:mirtop
 license: MIT License
 license_family: MIT
 name: mirtop

--- a/data/mirtop/bioconda_mirtop.yaml
+++ b/data/mirtop/bioconda_mirtop.yaml
@@ -1,0 +1,6 @@
+home: http://github.com/mirtop/mirtop
+license: MIT License
+license_family: MIT
+name: mirtop
+summary: Small RNA-seq annotation
+version: 0.4.23

--- a/data/mutmap/bioconda_mutmap.yaml
+++ b/data/mutmap/bioconda_mutmap.yaml
@@ -1,4 +1,8 @@
+biotools_id: mutmap
 home: https://github.com/YuSugihara/MutMap
+identifiers:
+- biotools:mutmap
+- doi:10.1038/nbt.2095
 license: GPL-3.0-or-later
 license_family: GPL
 name: mutmap

--- a/data/mutmap/bioconda_mutmap.yaml
+++ b/data/mutmap/bioconda_mutmap.yaml
@@ -1,0 +1,6 @@
+home: https://github.com/YuSugihara/MutMap
+license: GPL-3.0-or-later
+license_family: GPL
+name: mutmap
+summary: 'MutMap: pipeline to identify causative mutations responsible for a phenotype'
+version: 2.1.3

--- a/data/ngmerge/bioconda_ngmerge.yaml
+++ b/data/ngmerge/bioconda_ngmerge.yaml
@@ -1,0 +1,6 @@
+home: https://github.com/harvardinformatics/NGmerge
+license: MIT
+license_file: LICENSE
+name: ngmerge
+summary: Merging paired-end reads and removing sequencing adapters.
+version: 0.3

--- a/data/ngmerge/bioconda_ngmerge.yaml
+++ b/data/ngmerge/bioconda_ngmerge.yaml
@@ -1,4 +1,7 @@
+biotools_id: ngmerge
 home: https://github.com/harvardinformatics/NGmerge
+identifiers:
+- biotools:ngmerge
 license: MIT
 license_file: LICENSE
 name: ngmerge

--- a/data/pgcgap/bioconda_pgcgap.yaml
+++ b/data/pgcgap/bioconda_pgcgap.yaml
@@ -1,5 +1,8 @@
+biotools_id: pgcgap
 dev_url: https://github.com/liaochenlanruo/pgcgap/tree/master
 home: https://github.com/liaochenlanruo/pgcgap/blob/master/README.md
+identifiers:
+- biotools:pgcgap
 license: GPLv3
 license_family: GPL
 license_file: LICENSE

--- a/data/pgcgap/bioconda_pgcgap.yaml
+++ b/data/pgcgap/bioconda_pgcgap.yaml
@@ -1,0 +1,8 @@
+dev_url: https://github.com/liaochenlanruo/pgcgap/tree/master
+home: https://github.com/liaochenlanruo/pgcgap/blob/master/README.md
+license: GPLv3
+license_family: GPL
+license_file: LICENSE
+name: pgcgap
+summary: A prokaryotic genomics and comparative genomics analysis pipeline
+version: 1.0.9

--- a/data/phame/bioconda_phame.yaml
+++ b/data/phame/bioconda_phame.yaml
@@ -1,0 +1,6 @@
+home: https://github.com/LANL-Bioinformatics/PhaME
+license: GPLV2
+name: phame
+summary: A tool to derive SNP matrices and phylogenetic tree from raw reads, contigs,
+  and full genomes.
+version: 1.0.3

--- a/data/phame/bioconda_phame.yaml
+++ b/data/phame/bioconda_phame.yaml
@@ -1,4 +1,7 @@
+biotools_id: phame
 home: https://github.com/LANL-Bioinformatics/PhaME
+identifiers:
+- biotools:phame
 license: GPLV2
 name: phame
 summary: A tool to derive SNP matrices and phylogenetic tree from raw reads, contigs,

--- a/data/phylocsf/bioconda_phylocsf.yaml
+++ b/data/phylocsf/bioconda_phylocsf.yaml
@@ -1,4 +1,7 @@
+biotools_id: phylocsf
 home: https://github.com/mlin/PhyloCSF/wiki
+identifiers:
+- biotools:phyloCSF
 license: AGPL-3.0
 license_file: LICENSE
 name: phylocsf

--- a/data/phylocsf/bioconda_phylocsf.yaml
+++ b/data/phylocsf/bioconda_phylocsf.yaml
@@ -1,0 +1,7 @@
+home: https://github.com/mlin/PhyloCSF/wiki
+license: AGPL-3.0
+license_file: LICENSE
+name: phylocsf
+summary: Phylogenetic analysis of multi-species genome sequence alignments to identify
+  conserved protein-coding regions
+version: 1.0.1

--- a/data/pirate/bioconda_pirate.yaml
+++ b/data/pirate/bioconda_pirate.yaml
@@ -1,4 +1,8 @@
+biotools_id: pirate
 home: https://github.com/SionBayliss/PIRATE
+identifiers:
+- biotools:pirate
+- doi:10.1101/598391
 license: GPL3
 license_family: GPL
 license_file: LICENSE

--- a/data/pirate/bioconda_pirate.yaml
+++ b/data/pirate/bioconda_pirate.yaml
@@ -1,0 +1,7 @@
+home: https://github.com/SionBayliss/PIRATE
+license: GPL3
+license_family: GPL
+license_file: LICENSE
+name: pirate
+summary: Pangenome analysis and threshold evaluation toolbox
+version: 1.0.3

--- a/data/piret/bioconda_piret.yaml
+++ b/data/piret/bioconda_piret.yaml
@@ -1,4 +1,7 @@
+biotools_id: piret
 home: https://github.com/mshakya/PyPiReT
+identifiers:
+- biotools:piret
 license: GPLV2
 name: piret
 summary: A tool for conducting RNA seq analysis.

--- a/data/piret/bioconda_piret.yaml
+++ b/data/piret/bioconda_piret.yaml
@@ -1,0 +1,5 @@
+home: https://github.com/mshakya/PyPiReT
+license: GPLV2
+name: piret
+summary: A tool for conducting RNA seq analysis.
+version: 0.3.4

--- a/data/popera/bioconda_popera.yaml
+++ b/data/popera/bioconda_popera.yaml
@@ -1,0 +1,7 @@
+dev_url: https://github.com/forrestzhang/Popera
+home: https://github.com/forrestzhang/Popera
+license: MIT
+license_file: LICENSE
+name: popera
+summary: A software for DNase I hypersensitive sites identification.
+version: 1.0.3

--- a/data/popera/bioconda_popera.yaml
+++ b/data/popera/bioconda_popera.yaml
@@ -1,5 +1,8 @@
+biotools_id: popera
 dev_url: https://github.com/forrestzhang/Popera
 home: https://github.com/forrestzhang/Popera
+identifiers:
+- biotools:popera
 license: MIT
 license_file: LICENSE
 name: popera

--- a/data/qtlseq/bioconda_qtlseq.yaml
+++ b/data/qtlseq/bioconda_qtlseq.yaml
@@ -1,0 +1,6 @@
+home: https://github.com/YuSugihara/QTL-seq
+license: GPL-3.0-or-later
+license_family: GPL
+name: qtlseq
+summary: 'QTL-seq: pipeline to identify causative mutations responsible for a phenotype'
+version: 2.0.7

--- a/data/qtlseq/bioconda_qtlseq.yaml
+++ b/data/qtlseq/bioconda_qtlseq.yaml
@@ -1,4 +1,8 @@
+biotools_id: qtlseq
 home: https://github.com/YuSugihara/QTL-seq
+identifiers:
+- biotools:qtlseq
+- doi:10.1111/tpj.12105
 license: GPL-3.0-or-later
 license_family: GPL
 name: qtlseq

--- a/data/referenceseeker/bioconda_referenceseeker.yaml
+++ b/data/referenceseeker/bioconda_referenceseeker.yaml
@@ -1,0 +1,8 @@
+dev_url: https://github.com/oschwengers/referenceseeker
+home: https://github.com/oschwengers/referenceseeker
+license: GPLv3
+license_family: GPL
+license_file: LICENSE
+name: referenceseeker
+summary: Rapid determination of appropriate reference genomes.
+version: '1.4'

--- a/data/referenceseeker/bioconda_referenceseeker.yaml
+++ b/data/referenceseeker/bioconda_referenceseeker.yaml
@@ -1,5 +1,8 @@
+biotools_id: referenceseeker
 dev_url: https://github.com/oschwengers/referenceseeker
 home: https://github.com/oschwengers/referenceseeker
+identifiers:
+- biotools:referenceseeker
 license: GPLv3
 license_family: GPL
 license_file: LICENSE

--- a/data/sepp-refgg138/bioconda_sepp-refgg138.yaml
+++ b/data/sepp-refgg138/bioconda_sepp-refgg138.yaml
@@ -1,4 +1,7 @@
+biotools_id: sepp-refgg138
 home: https://github.com/smirarab/sepp-refs
+identifiers:
+- biotools:sepp-refgg138
 license: GPLv3
 license_family: GPL3
 license_file: LICENSE

--- a/data/sepp-refgg138/bioconda_sepp-refgg138.yaml
+++ b/data/sepp-refgg138/bioconda_sepp-refgg138.yaml
@@ -1,0 +1,7 @@
+home: https://github.com/smirarab/sepp-refs
+license: GPLv3
+license_family: GPL3
+license_file: LICENSE
+name: sepp-refgg138
+summary: SATe-enabled phylogenetic placement
+version: 4.3.6

--- a/data/sepp-refsilva128/bioconda_sepp-refsilva128.yaml
+++ b/data/sepp-refsilva128/bioconda_sepp-refsilva128.yaml
@@ -1,0 +1,7 @@
+home: https://github.com/smirarab/sepp-refs
+license: GPLv3
+license_family: GPL3
+license_file: LICENSE
+name: sepp-refsilva128
+summary: SATe-enabled phylogenetic placement
+version: 4.3.6

--- a/data/sepp-refsilva128/bioconda_sepp-refsilva128.yaml
+++ b/data/sepp-refsilva128/bioconda_sepp-refsilva128.yaml
@@ -1,4 +1,7 @@
+biotools_id: sepp-refsilva128
 home: https://github.com/smirarab/sepp-refs
+identifiers:
+- biotools:sepp-refsilva128
 license: GPLv3
 license_family: GPL3
 license_file: LICENSE

--- a/data/sepp/bioconda_sepp.yaml
+++ b/data/sepp/bioconda_sepp.yaml
@@ -1,4 +1,7 @@
+biotools_id: sepp
 home: https://github.com/smirarab/sepp
+identifiers:
+- biotools:sepp
 license: GPLv3
 license_family: GPL3
 license_file: LICENSE

--- a/data/sepp/bioconda_sepp.yaml
+++ b/data/sepp/bioconda_sepp.yaml
@@ -1,0 +1,7 @@
+home: https://github.com/smirarab/sepp
+license: GPLv3
+license_family: GPL3
+license_file: LICENSE
+name: sepp
+summary: SATe-enabled phylogenetic placement
+version: 4.3.10

--- a/data/shark/bioconda_shark.yaml
+++ b/data/shark/bioconda_shark.yaml
@@ -1,4 +1,7 @@
+biotools_id: shark
 home: https://algolab.github.io/shark/
+identifiers:
+- biotools:shark
 license: GPL-3.0-or-later
 license_file: LICENSE
 name: shark

--- a/data/shark/bioconda_shark.yaml
+++ b/data/shark/bioconda_shark.yaml
@@ -1,0 +1,6 @@
+home: https://algolab.github.io/shark/
+license: GPL-3.0-or-later
+license_file: LICENSE
+name: shark
+summary: Mapping-free filtering of useless RNA-Seq reads
+version: 1.0.0

--- a/data/slimm/bioconda_slimm.yaml
+++ b/data/slimm/bioconda_slimm.yaml
@@ -1,0 +1,5 @@
+home: https://github.com/seqan/slimm/blob/master/README.md
+license: https://github.com/seqan/slimm/blob/master/LICENSE
+name: slimm
+summary: SLIMM - Species Level Identification of Microbes from Metagenomes
+version: 0.3.4

--- a/data/slimm/bioconda_slimm.yaml
+++ b/data/slimm/bioconda_slimm.yaml
@@ -1,4 +1,8 @@
+biotools_id: slimm
 home: https://github.com/seqan/slimm/blob/master/README.md
+identifiers:
+- biotools:slimm
+- doi:10.7717/peerj.3138
 license: https://github.com/seqan/slimm/blob/master/LICENSE
 name: slimm
 summary: SLIMM - Species Level Identification of Microbes from Metagenomes

--- a/data/super_distance/bioconda_super_distance.yaml
+++ b/data/super_distance/bioconda_super_distance.yaml
@@ -1,4 +1,7 @@
+biotools_id: super_distance
 home: https://github.com/quadram-institute-bioscience/super_distance
+identifiers:
+- biotools:super_distance
 license: GPLv3
 license_file: LICENSE
 name: super_distance

--- a/data/super_distance/bioconda_super_distance.yaml
+++ b/data/super_distance/bioconda_super_distance.yaml
@@ -1,0 +1,6 @@
+home: https://github.com/quadram-institute-bioscience/super_distance
+license: GPLv3
+license_file: LICENSE
+name: super_distance
+summary: Supertree method with distances
+version: 1.1.0

--- a/data/taxonomy_ranks/bioconda_taxonomy_ranks.yaml
+++ b/data/taxonomy_ranks/bioconda_taxonomy_ranks.yaml
@@ -1,4 +1,7 @@
+biotools_id: taxonomy_ranks
 home: https://github.com/linzhi2013/taxonomy_ranks
+identifiers:
+- biotools:taxonomy_ranks
 license: GNU General Public v3 or later (GPLv3+)
 license_family: GPL3
 license_file: LICENSE

--- a/data/taxonomy_ranks/bioconda_taxonomy_ranks.yaml
+++ b/data/taxonomy_ranks/bioconda_taxonomy_ranks.yaml
@@ -1,0 +1,8 @@
+home: https://github.com/linzhi2013/taxonomy_ranks
+license: GNU General Public v3 or later (GPLv3+)
+license_family: GPL3
+license_file: LICENSE
+name: taxonomy_ranks
+summary: To get taxonomy ranks information for taxid, species name, or higher ranks
+  (e.g., genus, family) with ETE3 from NCBI Taxonomy database.
+version: 0.0.7

--- a/data/thesias/bioconda_thesias.yaml
+++ b/data/thesias/bioconda_thesias.yaml
@@ -1,0 +1,5 @@
+home: https://github.com/daissi/thesias
+license: GPL-3+
+name: thesias
+summary: Testing Haplotype Effects In Association Studies
+version: 3.1.1

--- a/data/thesias/bioconda_thesias.yaml
+++ b/data/thesias/bioconda_thesias.yaml
@@ -1,4 +1,8 @@
+biotools_id: thesias
 home: https://github.com/daissi/thesias
+identifiers:
+- biotools:THESIAS
+- doi:10.1093/bioinformatics/btm058
 license: GPL-3+
 name: thesias
 summary: Testing Haplotype Effects In Association Studies

--- a/data/wham6216/bioconda_wham6216.yaml
+++ b/data/wham6216/bioconda_wham6216.yaml
@@ -1,4 +1,7 @@
+biotools_id: wham6216
 home: https://github.com/zeeev/wham
+identifiers:
+- biotools:Wham6216
 license: MIT
 license_family: MIT
 name: wham

--- a/data/wham6216/bioconda_wham6216.yaml
+++ b/data/wham6216/bioconda_wham6216.yaml
@@ -1,0 +1,6 @@
+home: https://github.com/zeeev/wham
+license: MIT
+license_family: MIT
+name: wham
+summary: Structural variant detection and association testing
+version: 1.8.0.1.2017.05.03

--- a/data/womtool/bioconda_womtool.yaml
+++ b/data/womtool/bioconda_womtool.yaml
@@ -1,4 +1,7 @@
+biotools_id: womtool
 home: https://cromwell.readthedocs.io/en/develop/WOMtool/
+identifiers:
+- biotools:womtool
 license: BSD-3-Clause
 license_family: BSD
 license_file: LICENSE.txt

--- a/data/womtool/bioconda_womtool.yaml
+++ b/data/womtool/bioconda_womtool.yaml
@@ -1,0 +1,7 @@
+home: https://cromwell.readthedocs.io/en/develop/WOMtool/
+license: BSD-3-Clause
+license_family: BSD
+license_file: LICENSE.txt
+name: womtool
+summary: Command line utilities for interacting with WDL
+version: 48

--- a/data/xhmm/bioconda_xhmm.yaml
+++ b/data/xhmm/bioconda_xhmm.yaml
@@ -1,4 +1,9 @@
+biotools_id: xhmm
 home: http://atgu.mgh.harvard.edu/xhmm/index.shtml
+identifiers:
+- biotools:xhmm
+- doi:10.1016/j.ajhg.2012.08.005
+- doi:10.1002/0471142905.hg0723s81
 license: GPL3
 name: xhmm
 summary: XHMM (eXome-Hidden Markov Model).

--- a/data/xhmm/bioconda_xhmm.yaml
+++ b/data/xhmm/bioconda_xhmm.yaml
@@ -1,0 +1,5 @@
+home: http://atgu.mgh.harvard.edu/xhmm/index.shtml
+license: GPL3
+name: xhmm
+summary: XHMM (eXome-Hidden Markov Model).
+version: 0.0.0.2016_01_04.cc14e52


### PR DESCRIPTION
This add new bioconda yaml files, for tools that are currently missing from bio.tools.

We mapped bioconda-recipes that are annotated with bio.tools IDs to this repo ... if there was no mapping but in bioconda there was actually a bio.tools ID annotated ... we create here a new folder.

It is strange in the first place that this is happening. It can be because:

* bioconda contributors just add non-existing bio.tool IDs
* bio.tool IDs got removed
* the content repo is not up to date

I assume the first option. Eitherway, I think those tools are valid and should be merged ... later also added to bio.tools.