### PR TITLE
Don't include doi in json, if it is already there as not "Primary" type

### DIFF
--- a/scripts/doi-collector/doi_collector.py
+++ b/scripts/doi-collector/doi_collector.py
@@ -32,6 +32,8 @@ def enrich_dois(path):
     bioconda_dois = set()
     debian_dois = set()
 
+    non_primary_dois = set()
+
     def parse_yaml(file):
         with open(file, 'r') as stream:
                 return yaml.safe_load(stream)
@@ -48,6 +50,8 @@ def enrich_dois(path):
             for publication in publications:
                 if ('type' in publication and 'doi' in publication and publication['type'] == 'Primary'):
                     dois.add(publication['doi'])
+                elif ('type' in publication and 'doi' in publication and publication['type'] != 'Primary'):
+                    non_primary_dois.add(publication['doi'])
             return dois
         else:
             return []
@@ -72,6 +76,7 @@ def enrich_dois(path):
 
     def write_dois_json(json_dois, file):
         parsed_json = parse_json(file)
+        json_dois = json_dois.difference(non_primary_dois)
         if 'publication' not in parsed_json:
             parsed_json['publication'] = [{'doi': json_dois.pop(), 'type': 'Primary'}]
 


### PR DESCRIPTION
Fix for https://github.com/bio-tools/content/issues/213 . Thanks a lot @hansioan for discovering it!  
Don't include doi in bio.tools json, if it's defined already in non "Primary" type. I assume it's ok for @bgruening, that we share dois from Primary section to bioconda and debian (probably it was the goal at the first place)