### PR TITLE
fix debian in doi collector

### DIFF
--- a/.github/workflows/doi-load.yaml
+++ b/.github/workflows/doi-load.yaml
@@ -7,7 +7,7 @@ on:
 jobs:
   build:
 
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
 
     steps:
     - uses: actions/checkout@v2

--- a/scripts/doi-collector/doi_collector.py
+++ b/scripts/doi-collector/doi_collector.py
@@ -56,8 +56,13 @@ def enrich_dois(path):
         else:
             return []
 
-    def get_doi_identifiers_from_yaml(parsed_yaml):
+    def get_doi_identifiers_from_yaml(parsed_yaml, isDebian=False):
         if 'identifiers' in parsed_yaml:
+            if isDebian:
+                if "doi" in parsed_yaml['identifiers']:
+                    return parsed_yaml['identifiers']['doi']
+                else:
+                    return []
             return filter(lambda identifier: 'doi' in identifier, parsed_yaml['identifiers'])
 
     def extract_doi_from_bioconda_yaml(parsed_yaml):
@@ -66,12 +71,15 @@ def enrich_dois(path):
             map(lambda identifier_doi: identifier_doi.split(':')[1], get_doi_identifiers_from_yaml(parsed_yaml)))
 
     def extract_doi_from_debian(parsed_yaml):
-        dois = list(map(lambda identifier_doi: identifier_doi['doi'], get_doi_identifiers_from_yaml(parsed_yaml)))
+        # print(get_doi_identifiers_from_yaml(parsed_yaml)))
+        # print(get_doi_identifiers_from_yaml(parsed_yaml, True)["doi"])
+
+        # if "doi" not in get_doi_identifiers_from_yaml(parsed_yaml):
+        #         return []
+        dois = list(get_doi_identifiers_from_yaml(parsed_yaml, True))
         # if doi doesn't exist, return empty array
         if len(dois) == 0:
             return []
-        if type(dois[0]) == list:
-            return dois[0]
         return dois
 
     def write_dois_json(json_dois, file):
@@ -139,7 +147,6 @@ def enrich_dois(path):
             dois = extract_doi_from_debian(parsed_yaml)
             debian_dois = dois
 
-
         elif file.endswith(file_types['yaml']):
             parsed_yaml = parse_yaml(file)
             dois = extract_doi_from_bioconda_yaml(parsed_yaml)
@@ -152,7 +159,9 @@ def enrich_dois(path):
                 enrich_files(write_dois_json, json_dois, file)
 
             elif file.endswith(file_types['debian']):
-                enrich_files(write_dois_debian, debian_dois, file)
+                # skip debian writing files
+                continue
+                # enrich_files(write_dois_debian, debian_dois, file)
 
             elif file.endswith(file_types['yaml']):
                 enrich_files(write_dois_bioconda, bioconda_dois, file)

--- a/scripts/doi-collector/doi_collector.py
+++ b/scripts/doi-collector/doi_collector.py
@@ -59,10 +59,8 @@ def enrich_dois(path):
     def get_doi_identifiers_from_yaml(parsed_yaml, isDebian=False):
         if 'identifiers' in parsed_yaml:
             if isDebian:
-                if "doi" in parsed_yaml['identifiers']:
-                    return parsed_yaml['identifiers']['doi']
-                else:
-                    return []
+                # if doi entry exist return it, otherwise empty array
+                return parsed_yaml['identifiers']['doi'] if "doi" in parsed_yaml['identifiers'] else []
             return filter(lambda identifier: 'doi' in identifier, parsed_yaml['identifiers'])
 
     def extract_doi_from_bioconda_yaml(parsed_yaml):
@@ -71,11 +69,6 @@ def enrich_dois(path):
             map(lambda identifier_doi: identifier_doi.split(':')[1], get_doi_identifiers_from_yaml(parsed_yaml)))
 
     def extract_doi_from_debian(parsed_yaml):
-        # print(get_doi_identifiers_from_yaml(parsed_yaml)))
-        # print(get_doi_identifiers_from_yaml(parsed_yaml, True)["doi"])
-
-        # if "doi" not in get_doi_identifiers_from_yaml(parsed_yaml):
-        #         return []
         dois = list(get_doi_identifiers_from_yaml(parsed_yaml, True))
         # if doi doesn't exist, return empty array
         if len(dois) == 0:
@@ -106,17 +99,11 @@ def enrich_dois(path):
         parsed_yaml = parse_yaml(file)
         identifiers = parsed_yaml['identifiers']
         # if doi doesn't exist
-        if len(extract_doi_from_debian(parsed_yaml)) == 0:
-            identifiers.append({'doi': dois.pop()})
+        if 'doi' not in identifiers:
+            identifiers['doi'] = [dois.pop()]
 
         for doi in dois:
-            for i in range(len(identifiers)):
-                if ('doi' in identifiers[i]):
-                    # check if it's a single string, not an array
-                    if type(identifiers[i]['doi']) == list:
-                        identifiers[i]['doi'].append(doi)
-                    else:
-                        identifiers[i]['doi'] = [identifiers[i]['doi'], doi]
+            identifiers['doi'].append(doi)
 
         parsed_yaml['identifiers'] = identifiers
 
@@ -159,9 +146,7 @@ def enrich_dois(path):
                 enrich_files(write_dois_json, json_dois, file)
 
             elif file.endswith(file_types['debian']):
-                # skip debian writing files
-                continue
-                # enrich_files(write_dois_debian, debian_dois, file)
+                enrich_files(write_dois_debian, debian_dois, file)
 
             elif file.endswith(file_types['yaml']):
                 enrich_files(write_dois_bioconda, bioconda_dois, file)


### PR DESCRIPTION
So I guess debian files changed and that broke the last doi spreader. 
Anyway, can someone tell me what is the preferred format for doi in debian now?
Unfortunately, I did not find more than one doi entry in debian files :(

So what should the CI do if  it wants to merge https://github.com/bio-tools/content/blob/master/data/hisat2/bioconda_hisat2.yaml#L5 into https://github.com/bio-tools/content/blob/master/data/hisat2/hisat2.debian.yaml#L19 ?

This PR makes them read-only for now. It still will harvest dois, but will not commit anything to Debian

@hmenager  @matuskalas @bgruening @hansioan 