### PR TITLE
fix faulty doi in bioconda

### DIFF
--- a/data/multiqc/bioconda_multiqc.yaml
+++ b/data/multiqc/bioconda_multiqc.yaml
@@ -4,7 +4,6 @@ doc_url: http://multiqc.info/docs/
 home: http://multiqc.info
 identifiers:
 - biotools:multiqc
-- doi:https://doi.org/10.1093/bioinformatics/btw354
 - doi:10.1093/bioinformatics/btw354
 license: GNU General Public License v3 (GPLv3)
 license_family: GPL3


### PR DESCRIPTION
a link is not a doi (especially, when the same doi is listed alongside)