### PR TITLE
bio-containers annotation import

### DIFF
--- a/.github/workflows/biocontainers-import.yaml
+++ b/.github/workflows/biocontainers-import.yaml
@@ -1,0 +1,53 @@
+name: bioconda import
+
+on:
+  schedule:
+    - cron: "0 0 * * 0"
+  workflow_dispatch:
+
+jobs:
+  build:
+
+    runs-on: ubuntu-20.04
+
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        repository: bio-tools/content-ecosystem-utils
+        path: content-ecosystem-utils
+    - uses: actions/checkout@v2
+      with:
+        repository: bioconda/bioconda-recipes
+        path: bioconda
+    - uses: actions/checkout@v2
+      with:
+        path: content
+    - name: import bioconda tools
+      env:
+        GITHUB_USER: ${{ secrets.GITHUB_USER }}
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        BIOCONTAINERS_URL: https://raw.githubusercontent.com/BioContainers/tools-metadata/master/annotations.yaml
+      run: |
+        cd ${{ github.workspace }}/content/data
+
+        if ${{ github.workspace }}/content-ecosystem-utils/scripts/git-utils/checkout-pr-if-exist.sh bioconda-import; then
+          IS_PR_CREATED=true
+        else
+          IS_PR_CREATED=false
+        fi
+
+        # Run importing script
+        sudo pip3 install virtualenv
+        virtualenv -p python3 venv
+        . venv/bin/activate
+        pip3 install setuptools wheel jinja2 pyyaml
+        python3 ${{ github.workspace }}/content-ecosystem-utils/scripts/bioconda-import/bioconda_importer.py ${{ github.workspace }}/content/data/ $BIOCONTAINERS_URL
+
+        ${{ github.workspace }}/content-ecosystem-utils/scripts/git-utils/import-changes.sh $IS_PR_CREATED biocontainers-import
+
+    - name: Cache multiple paths
+      uses: actions/cache@v2
+      with:
+        path: |
+          .venv/
+        key: ${{ runner.os }}-biocontainers-import

--- a/.github/workflows/biocontainers-import.yaml
+++ b/.github/workflows/biocontainers-import.yaml
@@ -34,7 +34,7 @@ jobs:
         sudo pip3 install virtualenv
         virtualenv -p python3 venv
         . venv/bin/activate
-        pip3 install setuptools wheel jinja2 pyyaml
+        pip3 install setuptools wheel jinja2 pyyaml requests
         python3 ${{ github.workspace }}/content-ecosystem-utils/scripts/biocontainers-annotations-import/biocontainers-importer.py ${{ github.workspace }}/content/data/ $BIOCONTAINERS_URL
 
         ${{ github.workspace }}/content-ecosystem-utils/scripts/git-utils/import-changes.sh $IS_PR_CREATED biocontainers-import

--- a/.github/workflows/biocontainers-import.yaml
+++ b/.github/workflows/biocontainers-import.yaml
@@ -1,8 +1,8 @@
 name: bioconda import
 
 on:
-  schedule:
-    - cron: "0 0 * * 0"
+  workflow_dispatch:
+
 
 jobs:
   build:
@@ -26,7 +26,7 @@ jobs:
       run: |
         cd ${{ github.workspace }}/content/data
 
-        if ${{ github.workspace }}/content-ecosystem-utils/scripts/git-utils/checkout-pr-if-exist.sh bioconda-import; then
+        if ${{ github.workspace }}/content-ecosystem-utils/scripts/git-utils/checkout-pr-if-exist.sh biocontainers-import; then
           IS_PR_CREATED=true
         else
           IS_PR_CREATED=false

--- a/.github/workflows/biocontainers-import.yaml
+++ b/.github/workflows/biocontainers-import.yaml
@@ -1,6 +1,8 @@
 name: bioconda import
 
-on: push
+on:
+  schedule:
+    - cron: "0 0 * * 0"
 
 jobs:
   build:
@@ -16,7 +18,7 @@ jobs:
     - uses: actions/checkout@v2
       with:
         path: content
-    - name: import bioconda tools
+    - name: import biocontainers annotations
       env:
         GITHUB_USER: ${{ secrets.GITHUB_USER }}
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/biocontainers-import.yaml
+++ b/.github/workflows/biocontainers-import.yaml
@@ -1,9 +1,6 @@
 name: bioconda import
 
-on:
-  schedule:
-    - cron: "0 0 * * 0"
-  workflow_dispatch:
+on: push
 
 jobs:
   build:
@@ -15,6 +12,7 @@ jobs:
       with:
         repository: bio-tools/content-ecosystem-utils
         path: content-ecosystem-utils
+        ref: 'biocontainers-annotation-import'
     - uses: actions/checkout@v2
       with:
         repository: bioconda/bioconda-recipes

--- a/.github/workflows/biocontainers-import.yaml
+++ b/.github/workflows/biocontainers-import.yaml
@@ -15,10 +15,6 @@ jobs:
         ref: 'biocontainers-annotation-import'
     - uses: actions/checkout@v2
       with:
-        repository: bioconda/bioconda-recipes
-        path: bioconda
-    - uses: actions/checkout@v2
-      with:
         path: content
     - name: import bioconda tools
       env:
@@ -39,7 +35,7 @@ jobs:
         virtualenv -p python3 venv
         . venv/bin/activate
         pip3 install setuptools wheel jinja2 pyyaml
-        python3 ${{ github.workspace }}/scripts/biocontainers-annotations-import/biocontainers-importer.py ${{ github.workspace }}/content/data/ $BIOCONTAINERS_URL
+        python3 ${{ github.workspace }}/content-ecosystem-utils/scripts/biocontainers-annotations-import/biocontainers-importer.py ${{ github.workspace }}/content/data/ $BIOCONTAINERS_URL
 
         ${{ github.workspace }}/content-ecosystem-utils/scripts/git-utils/import-changes.sh $IS_PR_CREATED biocontainers-import
 

--- a/.github/workflows/biocontainers-import.yaml
+++ b/.github/workflows/biocontainers-import.yaml
@@ -39,7 +39,7 @@ jobs:
         virtualenv -p python3 venv
         . venv/bin/activate
         pip3 install setuptools wheel jinja2 pyyaml
-        python3 ${{ github.workspace }}/content-ecosystem-utils/scripts/bioconda-import/bioconda_importer.py ${{ github.workspace }}/content/data/ $BIOCONTAINERS_URL
+        python3 ${{ github.workspace }}/scripts/biocontainers-annotations-import/biocontainers-importer.py ${{ github.workspace }}/content/data/ $BIOCONTAINERS_URL
 
         ${{ github.workspace }}/content-ecosystem-utils/scripts/git-utils/import-changes.sh $IS_PR_CREATED biocontainers-import
 

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
-data/*
+data/*/*
 
 !*.json
 !*.yaml


### PR DESCRIPTION
As we discussed today with @hmenager @bgruening @hansioan @redmitry 
Here is the PR that parses [biocontainers annotations](https://raw.githubusercontent.com/BioContainers/tools-metadata/master/annotations.yaml). Currently CI usses this [branch](https://github.com/bio-tools/content-ecosystem-utils/tree/biocontainers-annotation-import) of `content-ecosystem-utils`
Current strategy:
 If we find a new tool, we create new directory under `data/`. (this is of course disputable. Any other ideas are always appreciated, please say so if you think otherwise)

Example of PR created by bot: https://github.com/OlegZharkov/content/pull/204